### PR TITLE
Update GCC download link

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,7 @@ jobs:
   steps:
 
   - script: |
-      curl -L https://n64tools.blob.core.windows.net/binaries/N64-tools/mips64-gcc-toolchain/master/latest/gcc-toolchain-mips64-win64.zip --output gcc-toolchain-mips64-win64.zip
+      curl -L https://github.com/N64-tools/mips64-gcc-toolchain/releases/download/latest/gcc-toolchain-mips64-win64.zip --output gcc-toolchain-mips64-win64.zip
       curl -L https://raw.githubusercontent.com/tronkko/dirent/master/include/dirent.h --output ./include/dirent.h
       curl -L https://windows.php.net/downloads/php-sdk/deps/vc15/x64/libpng-1.6.34-2-vc15-x64.zip --output libpng.zip
     displayName: 'Get dependencies'


### PR DESCRIPTION
The GCC toolchain is no longer available from the blob.